### PR TITLE
fix errors

### DIFF
--- a/MCP4728.h
+++ b/MCP4728.h
@@ -24,7 +24,7 @@ public:
     enum class PWR_DOWN { NORMAL, GND_1KOHM, GND_100KOHM, GND_500KOHM };
     enum class GAIN { X1, X2 };
 
-    void attatch(TwoWire& w, uint8_t pin)
+    void attach(TwoWire& w, uint8_t pin)
     {
         wire_ = &w;
         pin_ldac_ = pin;

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ void setup()
 {
     Serial.begin(115200);  // initialize serial interface for print()
 
-    Wire.begin(21, 22);
-    dac.attatch(Wire, 14);
+    Wire.begin();
+    dac.attach(Wire, 14);
     dac.readRegisters();
 
     dac.selectVref(MCP4728::VREF::VDD, MCP4728::VREF::VDD, MCP4728::VREF::INTERNAL_2_8V, MCP4728::VREF::INTERNAL_2_8V);

--- a/example/example.ino
+++ b/example/example.ino
@@ -8,7 +8,7 @@ void setup()
     Serial.begin(115200);  // initialize serial interface for print()
 
     Wire.begin();
-    dac.attatch(Wire, 14);
+    dac.attach(Wire, 14);
     dac.readRegisters();
 
     dac.selectVref(MCP4728::VREF::VDD, MCP4728::VREF::VDD, MCP4728::VREF::INTERNAL_2_8V, MCP4728::VREF::INTERNAL_2_8V);


### PR DESCRIPTION
fix typo: attatch -> attach
fix error in sample code in README.md: Wire.begin(21, 22) -> Wire.begin()